### PR TITLE
Dev

### DIFF
--- a/apps/front/src/modules/pacientes/modals/ConsultaModal.tsx
+++ b/apps/front/src/modules/pacientes/modals/ConsultaModal.tsx
@@ -65,7 +65,8 @@ const ConsultaModal: React.FC<ConsultaModalProps> = ({
                 </Form.Item>
                 <Form.Item 
                     label="Anexos"
-                    >
+                    extra="Você pode enviar até 5 arquivos no formato PDF."
+                >
                     <Upload
                         beforeUpload={() => false}
                         fileList={fileList}
@@ -75,7 +76,7 @@ const ConsultaModal: React.FC<ConsultaModalProps> = ({
                         maxCount={5}
                     >
                         <Button icon={<UploadOutlined />}>Upload</Button>
-                        </Upload>
+                    </Upload>
                 </Form.Item>
                 <Form.Item>
                     <Button type="primary" htmlType="submit">


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `ConsultaModal` component in the `apps/front/src/modules/pacientes/modals/ConsultaModal.tsx` file. The change provides additional user guidance by specifying the file upload limitations directly in the UI.

* [`apps/front/src/modules/pacientes/modals/ConsultaModal.tsx`](diffhunk://#diff-d782fd078b3279eb4abb8a8257c2e8b314eb078237c3c33d9d608bdec695d6c5R68): Added an `extra` prop to the "Anexos" form item, informing users that they can upload up to 5 PDF files.