### PR TITLE
Refactor/ajustar permissoes

### DIFF
--- a/apps/front/src/modules/pacientes/pages/dashboard/index.tsx
+++ b/apps/front/src/modules/pacientes/pages/dashboard/index.tsx
@@ -2,6 +2,7 @@ import { DeleteOutlined, EditOutlined, PlusOutlined, SearchOutlined } from "@ant
 import { Button, Input, Popconfirm, Space, Table, Typography } from "antd";
 import { useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
+import { useCurrentUser } from "../../../auth/hooks/authHooks";
 import { handleError } from "../../../../utils/error-handler";
 import ToastService from "../../../../utils/toast-service";
 import { usePaciente } from "../../hooks/pacienteHooks";
@@ -13,6 +14,9 @@ const { Title } = Typography;
 
 const Paciente : React.FC = () => {
     const navigate = useNavigate();
+    const { data: currentUser } = useCurrentUser();
+    const isAdmin = currentUser?.cargo === "ADM";
+    
     const {
         pagination,
         searchText,
@@ -51,48 +55,56 @@ const Paciente : React.FC = () => {
         }, [error]);
 
     const columns = useMemo(
-        () => [
-            { title: "Nome", dataIndex: "nome", key: "nome" },
-            { title: "CPF", dataIndex: "cpf", key: "cpf"},
-            {
-                title: "Telefone",
-                dataIndex: "telefone",
-                key: "telefone",
-            },
-            {
-                title: "Endereço",
-                dataIndex: "endereco",
-                key: "endereco",
-            },
-            {
-                title: "Ações",
-                key: "actions",
-                width: 150,
-                render: (_: unknown, record: Paciente) => (
-                    <Space size="middle">
-                        <Button
-                            type="text"
-                            icon={<EditOutlined />}
-                            onClick={() => openEditModal(record)}
-                        />
-                        <Popconfirm
-                            title="Tem certeza que deseja excluir esta UBS?"
-                            onConfirm={() => handleDelete(record.id)}
-                            okText="Sim"
-                            cancelText="Não"
-                        >
+        () => {
+            const baseColumns: any[] = [
+                { title: "Nome", dataIndex: "nome", key: "nome" },
+                { title: "CPF", dataIndex: "cpf", key: "cpf"},
+                {
+                    title: "Telefone",
+                    dataIndex: "telefone",
+                    key: "telefone",
+                },
+                {
+                    title: "Endereço",
+                    dataIndex: "endereco",
+                    key: "endereco",
+                },
+            ];
+
+            // Apenas adiciona a coluna de ações se NÃO for administrador
+            if (!isAdmin) {
+                baseColumns.push({
+                    title: "Ações",
+                    key: "actions",
+                    width: 150,
+                    render: (_: unknown, record: Paciente) => (
+                        <Space size="middle">
                             <Button
-                                danger
                                 type="text"
-                                icon={<DeleteOutlined />}
-                                loading={isDeleting}
+                                icon={<EditOutlined />}
+                                onClick={() => openEditModal(record)}
                             />
-                        </Popconfirm>
-                    </Space>
-                ),
-            },
-        ],
-        [ openEditModal, handleDelete, isDeleting ],
+                            <Popconfirm
+                                title="Tem certeza que deseja excluir este paciente?"
+                                onConfirm={() => handleDelete(record.id)}
+                                okText="Sim"
+                                cancelText="Não"
+                            >
+                                <Button
+                                    danger
+                                    type="text"
+                                    icon={<DeleteOutlined />}
+                                    loading={isDeleting}
+                                />
+                            </Popconfirm>
+                        </Space>
+                    ),
+                });
+            }
+
+            return baseColumns;
+        },
+        [ isAdmin, openEditModal, handleDelete, isDeleting ],
     );
 
 
@@ -117,13 +129,15 @@ const Paciente : React.FC = () => {
                     icon={<SearchOutlined />}
                     onClick={handleSearch}
                 />
-                <Button
-                    type="primary"
-                    icon={<PlusOutlined />}
-                    onClick={openModal}
-                >
-                    Cadastrar Paciente
-                </Button>
+                {!isAdmin && (
+                    <Button
+                        type="primary"
+                        icon={<PlusOutlined />}
+                        onClick={openModal}
+                    >
+                        Cadastrar Paciente
+                    </Button>
+                )}
         </Space>
       </div>
 
@@ -150,29 +164,31 @@ const Paciente : React.FC = () => {
                         onShowSizeChange: (_, size) =>
                             setPagination({ current: 1, pageSize: size }),
                 }}
-                onRow={(record) => ({
+                onRow={!isAdmin ? (record) => ({
                     onClick: () => navigate(`/pacientes/${record.id}`),
-                })}
+                }) : undefined}
             />
         )}
 
-        <PacienteModal
-                visible={isModalVisible}
-                editingId={editingPaciente?.id || null}
-                onCancel={closeModal}
-                onSubmit={handleSubmit}
-                loading={isSubmitting}
-                initialValues={
-                    editingPaciente
-                        ? {
-                              cpf: editingPaciente.cpf,
-                              nome: editingPaciente.nome,
-                              endereco: editingPaciente.endereco,
-                              telefone: editingPaciente.telefone,
-                          }
-                        : undefined
-                }
-            />
+        {!isAdmin && (
+            <PacienteModal
+                    visible={isModalVisible}
+                    editingId={editingPaciente?.id || null}
+                    onCancel={closeModal}
+                    onSubmit={handleSubmit}
+                    loading={isSubmitting}
+                    initialValues={
+                        editingPaciente
+                            ? {
+                                  cpf: editingPaciente.cpf,
+                                  nome: editingPaciente.nome,
+                                  endereco: editingPaciente.endereco,
+                                  telefone: editingPaciente.telefone,
+                              }
+                            : undefined
+                    }
+                />
+        )}
       </div>
   );
 };

--- a/apps/front/src/modules/pacientes/pages/pacienteDetails/PacienteDetalhesContent.tsx
+++ b/apps/front/src/modules/pacientes/pages/pacienteDetails/PacienteDetalhesContent.tsx
@@ -14,6 +14,7 @@ import {
     Typography,
 } from "antd";
 import React, { lazy, Suspense, useMemo } from "react";
+import { useCurrentUser } from "../../../auth/hooks/authHooks";
 import {
     useConsultasByGestacaoID,
     useGestacaoByPacienteID,
@@ -45,6 +46,9 @@ interface PacienteDetalhesContentProps {
 const PacienteDetalhesContent: React.FC<PacienteDetalhesContentProps> = ({
     pacienteId,
 }) => {
+    const { data: currentUser } = useCurrentUser();
+    const isAdmin = currentUser?.cargo === "ADM";
+    
     const {
         isModalVisible,
         openModal,
@@ -109,58 +113,81 @@ const PacienteDetalhesContent: React.FC<PacienteDetalhesContentProps> = ({
     // --- //
 
     const columns = useMemo(
-        () => [
-            {
-                title: "Data",
-                dataIndex: "createdAt",
-                key: "createdAt",
-                render: (value: string) =>
-                    new Date(value).toLocaleString("pt-BR", {
-                        day: "2-digit",
-                        month: "2-digit",
-                        year: "numeric",
-                    }),
-            },
-            {
-                title: "Médico",
-                dataIndex: ["medico", "nome"],
-                key: "medico",
-            },
-            {
-                title: "Unidade",
-                key: "unidade",
-                render: (_: any, record: Consulta) =>
-                    record.ubs?.nome || record.policlinica?.nome || "",
-            },
-            {
-                title: "Ações",
-                key: "actions",
-                width: 150,
-                fixed: "right" as const,
-                render: (_: unknown, record: Consulta) => (
-                    <Space size="middle">
+        () => {
+            const baseColumns: any[] = [
+                {
+                    title: "Data",
+                    dataIndex: "createdAt",
+                    key: "createdAt",
+                    render: (value: string) =>
+                        new Date(value).toLocaleString("pt-BR", {
+                            day: "2-digit",
+                            month: "2-digit",
+                            year: "numeric",
+                        }),
+                },
+                {
+                    title: "Médico",
+                    dataIndex: ["medico", "nome"],
+                    key: "medico",
+                },
+                {
+                    title: "Unidade",
+                    key: "unidade",
+                    render: (_: any, record: Consulta) =>
+                        record.ubs?.nome || record.policlinica?.nome || "",
+                },
+            ];
+
+            // Apenas adiciona a coluna de ações se não for administrador
+            if (!isAdmin) {
+                baseColumns.push({
+                    title: "Ações",
+                    key: "actions",
+                    width: 150,
+                    fixed: "right" as const,
+                    render: (_: unknown, record: Consulta) => (
+                        <Space size="middle">
+                            <Button
+                                onClick={() => handleViewConsulta(record)}
+                                type="text"
+                                icon={<EyeOutlined />}
+                            />
+                            <Popconfirm
+                                title="Excluir consulta?"
+                                okText="Sim"
+                                cancelText="Não"
+                                onConfirm={() => handleDelete(record.id)}
+                            >
+                                <Button
+                                    danger
+                                    type="text"
+                                    icon={<DeleteOutlined />}
+                                />
+                            </Popconfirm>
+                        </Space>
+                    ),
+                });
+            } else {
+                // Para administradores, apenas mostra o botão de visualizar
+                baseColumns.push({
+                    title: "Ações",
+                    key: "actions",
+                    width: 80,
+                    fixed: "right" as const,
+                    render: (_: unknown, record: Consulta) => (
                         <Button
                             onClick={() => handleViewConsulta(record)}
                             type="text"
                             icon={<EyeOutlined />}
                         />
-                        <Popconfirm
-                            title="Excluir consulta?"
-                            okText="Sim"
-                            cancelText="Não"
-                            onConfirm={() => handleDelete(record.id)}
-                        >
-                            <Button
-                                danger
-                                type="text"
-                                icon={<DeleteOutlined />}
-                            />
-                        </Popconfirm>
-                    </Space>
-                ),
-            },
-        ],
-        [],
+                    ),
+                });
+            }
+
+            return baseColumns;
+        },
+        [isAdmin, handleViewConsulta, handleDelete],
     );
 
     return (
@@ -193,20 +220,24 @@ const PacienteDetalhesContent: React.FC<PacienteDetalhesContentProps> = ({
                             allowClear
                         />
                         <Button type="default" icon={<SearchOutlined />} />
-                        <Button
-                            type="primary"
-                            icon={<PlusOutlined />}
-                            onClick={openModal}
-                        >
-                            Cadastrar Atendimento
-                        </Button>
-                        <Button
-                            type="primary"
-                            icon={<PlusOutlined />}
-                            onClick={openCreateGestacaoModal}
-                        >
-                            Cadastrar Gestação
-                        </Button>
+                        {!isAdmin && (
+                            <>
+                                <Button
+                                    type="primary"
+                                    icon={<PlusOutlined />}
+                                    onClick={openModal}
+                                >
+                                    Cadastrar Atendimento
+                                </Button>
+                                <Button
+                                    type="primary"
+                                    icon={<PlusOutlined />}
+                                    onClick={openCreateGestacaoModal}
+                                >
+                                    Cadastrar Gestação
+                                </Button>
+                            </>
+                        )}
                     </Space>
                 </div>
                 <div className="flex-1 overflow-auto p-4">
@@ -232,24 +263,28 @@ const PacienteDetalhesContent: React.FC<PacienteDetalhesContentProps> = ({
             </div>
             <ChatGestacao gestacaoId={gestacaoId} />
 
-            <GestacaoCreateModal
-                visible={isCreateGestacaoModalVisible}
-                onCancel={() => setIsCreateGestacaoModalVisible(false)}
-                onSubmit={handleGestacaoSubmitWithPaciente}
-                initialValues={undefined}
-            />
+            {!isAdmin && (
+                <>
+                    <GestacaoCreateModal
+                        visible={isCreateGestacaoModalVisible}
+                        onCancel={() => setIsCreateGestacaoModalVisible(false)}
+                        onSubmit={handleGestacaoSubmitWithPaciente}
+                        initialValues={undefined}
+                    />
+
+                    <ConsultaModal
+                        visible={isModalVisible}
+                        onCancel={closeModal}
+                        onSubmit={handleSubmit}
+                        initialValues={undefined}
+                    />
+                </>
+            )}
 
             <ConsultaDetailsModal
                 visible={isDetailsModalVisible}
                 onCancel={() => setIsDetailsModalVisible(false)}
                 initialValues={atendimentoDetails}
-            />
-
-            <ConsultaModal
-                visible={isModalVisible}
-                onCancel={closeModal}
-                onSubmit={handleSubmit}
-                initialValues={undefined}
             />
         </div>
     );

--- a/apps/front/src/pages/WorkInProgress.tsx
+++ b/apps/front/src/pages/WorkInProgress.tsx
@@ -97,9 +97,9 @@ const WorkInProgress: React.FC<WorkInProgressProps> = ({
                         type="primary"
                         size="large"
                         icon={<HomeOutlined />}
-                        onClick={() => navigate("/")}
+                        onClick={() => navigate("/pacientes")}
                     >
-                        Ir para o Dashboard
+                        Ir para a página de Pacientes
                     </Button>
                 </Space>
             </div>

--- a/apps/front/src/routes/routes.config.tsx
+++ b/apps/front/src/routes/routes.config.tsx
@@ -13,16 +13,16 @@ const ALL_ROLES = [ROLES.ADMIN, ROLES.MEDICO, ROLES.ENFERMEIRO];
 const CLINICAL_STAFF = [ROLES.MEDICO, ROLES.ENFERMEIRO];
 
 export const routes: RouteDefinition[] = [
-    {
-        path: "/",
-        label: "Dashboard",
-        icon: <DashboardOutlined />,
-    },
-    {
-        path: "/gestacoes",
-        label: "Gestações",
-        icon: <MedicineBoxOutlined />,
-    },
+    // {
+    //     path: "/",
+    //     label: "Dashboard",
+    //     icon: <DashboardOutlined />,
+    // },
+    // {
+    //     path: "/gestacoes",
+    //     label: "Gestações",
+    //     icon: <MedicineBoxOutlined />,
+    // },
     {
         path: "/pacientes",
         label: "Pacientes",


### PR DESCRIPTION
This pull request updates the patient dashboard and patient details pages to restrict certain actions and UI elements based on user roles, specifically hiding creation and modification features from administrators. It also improves the clarity of action columns in tables and updates navigation to direct users to the patient page. Additionally, some unused routes are commented out in the configuration.

**Role-based UI and action restrictions:**

* Added logic in both `dashboard/index.tsx` and `pacienteDetails/PacienteDetalhesContent.tsx` to detect if the current user is an administrator (`ADM`), and conditionally hide or show action buttons, modals, and table columns accordingly. Administrators now only see view actions, while other users can create, edit, and delete records. [[1]](diffhunk://#diff-16ee84ff10d441902cd7f42857bae977bc9fa0c2059b417446d03714c02dd271R17-R19) [[2]](diffhunk://#diff-7132287b1a1ef8964cad93ccda8274c961b574d0f7aecdf77768736488f1ef81R49-R51)
* In patient dashboard, the "Cadastrar Paciente" button and patient modals are hidden for administrators, and the "Ações" column is only shown for non-admins. [[1]](diffhunk://#diff-16ee84ff10d441902cd7f42857bae977bc9fa0c2059b417446d03714c02dd271L67-R76) [[2]](diffhunk://#diff-16ee84ff10d441902cd7f42857bae977bc9fa0c2059b417446d03714c02dd271R132-R140) [[3]](diffhunk://#diff-16ee84ff10d441902cd7f42857bae977bc9fa0c2059b417446d03714c02dd271R191)
* In patient details, the "Cadastrar Gestação" and related modals are only available to non-admins, and the actions column in the consultations table displays only a view button for admins. [[1]](diffhunk://#diff-7132287b1a1ef8964cad93ccda8274c961b574d0f7aecdf77768736488f1ef81L135-R144) [[2]](diffhunk://#diff-7132287b1a1ef8964cad93ccda8274c961b574d0f7aecdf77768736488f1ef81R223-R224) [[3]](diffhunk://#diff-7132287b1a1ef8964cad93ccda8274c961b574d0f7aecdf77768736488f1ef81R266-R288)

**UI and navigation improvements:**

* Updated the confirmation message for deleting a patient to be more accurate.
* Changed the "Ir para o Dashboard" button in the work-in-progress page to "Ir para a página de Pacientes" and updated its navigation target.

**Routing configuration:**

* Commented out unused dashboard and gestation routes in `routes.config.tsx`, leaving only the patient page route active.